### PR TITLE
Added more stringent validation on extension id and extension name

### DIFF
--- a/generators/app/utility.js
+++ b/generators/app/utility.js
@@ -8,11 +8,13 @@ function validateRequired(input, msg) {
 }
 
 function validateExtensionId(input) {
+      var extensionIdValidatorRegExp = /^[a-z0-9][a-z0-9\-]*$/i;
+
       if (!input) {
             return `You must provide an Id for your extension`
       } else {
-            if (input.indexOf(' ') >= 0) {
-                  return `The extension Id should not contain space`;
+            if (input.match(extensionIdValidatorRegExp) === null) {
+                  return `Extension Id should start with an alphanumeric char followed by a sequence of alphanumeric chars or a hyphen (-)`;
             } else {
                   return true;
             }
@@ -20,7 +22,17 @@ function validateExtensionId(input) {
 }
 
 function validateExtensionName(input) {
-      return validateRequired(input, `You must provide a name for your extension`);
+      var extensionNameValidatorRegExp = /^[a-z0-9].*$/i;
+      
+      if(!input) {
+            return validateRequired(input, `You must provide a name for your extension`);
+      } else {
+            if (input.match(extensionNameValidatorRegExp) === null) {
+                  return `Extension name should start with an alphanumeric character`;
+            } else {
+                  return true;
+            }
+      }
 }
 
 function validateExtensionType(input) {


### PR DESCRIPTION
Thank you for your pull request!
By completing this pull request, you agree to the [Contributing License Agreement](https://github.com/ALM-Rangers/Yeoman-extension-code-generator/blob/master/.github/CLA.md).

Changes proposed in this pull request:  
- Stringent validation of extension id (the extension id must start with an alpha char and then alpha char or hyphens only)
- Stringent validation of extension name (must start with an alphanumeric char)

No validation was being performed on extension id, it could later fail on either packaging or publishing to the marketplace

@ALM-Rangers/Yeoman-extension-code-generator
