### PR TITLE
update MSDN links to vsts extending overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ We've included **//TODO:** placeholders in the generated license, thirdpartynoti
 
 Take a look at the information on getting started with extensions, RESTful APIs, SDK, and the marketplace. I
 
-- [Overview](https://www.visualstudio.com/en-us/docs/integrate/extensions/overview)
+- [Overview](https://docs.microsoft.com/en-us/vsts/extend/overview)
 - [RESTful API Library](https://www.visualstudio.com/en-us/docs/integrate/api/overview)
 - [SDK](https://github.com/Microsoft/vss-web-extension-sdk)
 - [VSTS Marketplace](https://marketplace.visualstudio.com/VSTS)

--- a/generators/hub/templates/readme.md
+++ b/generators/hub/templates/readme.md
@@ -17,7 +17,7 @@ This has been updated to be inline with the [M109](https://www.visualstudio.com/
 #### If you run into any issues with the version of Node that is installed with the Node.js Tools for Visual Studio, you can change the path to Node by going into Tools -> Options -> Projects and Solutions -> External Web Tools.
 
 ### For further information, please consult the following websites:
-- The VSTS Extensions page on [MSDN](https://www.visualstudio.com/en-us/integrate/extensions/overview)
+- The VSTS Extensions page on [MSDN](https://docs.microsoft.com/en-us/vsts/extend/overview)
 - The VSTS Extensions sample repo on [GitHub](https://github.com/Microsoft/vsts-extension-samples)
 - A great [example](https://binary-stuff.com/post/a-hello-world-for-vso-extensions) project from Visual Studio ALM Ranger Gordon Beeming
 

--- a/generators/widget/templates/readme.md
+++ b/generators/widget/templates/readme.md
@@ -17,7 +17,7 @@ This has been updated to be inline with the [M109](https://www.visualstudio.com/
 #### If you run into any issues with the version of Node that is installed with the Node.js Tools for Visual Studio, you can change the path to Node by going into Tools -> Options -> Projects and Solutions -> External Web Tools.
 
 ### For further information, please consult the following websites:
-- The VSTS Extensions page on [MSDN](https://www.visualstudio.com/en-us/integrate/extensions/overview)
+- The VSTS Extensions page on [MSDN](https://docs.microsoft.com/en-us/vsts/extend/overview)
 - The VSTS Extensions sample repo on [GitHub](https://github.com/Microsoft/vsts-extension-samples)
 - A great [example](https://binary-stuff.com/post/a-hello-world-for-vso-extensions) project from Visual Studio ALM Ranger Gordon Beeming
 


### PR DESCRIPTION
Fixes several broken links to the vsts extension overview documentation