### PR TITLE
Changed Task Generation to be Cross Platform

### DIFF
--- a/generators/taskitem/index.js
+++ b/generators/taskitem/index.js
@@ -182,17 +182,17 @@ function writeFiles() {
 
       if (this.taskScripting == "PowerShell") {
             this.fs.copyTpl(
-                  this.templatePath('Task/task.ps1'),
+                  this.templatePath('task/task.ps1'),
                   this.destinationPath(taskFolder + '/' + this.taskName + '.ps1'), tokens
             );
       } else if (this.taskScripting == "TypeScript") {
             this.fs.copyTpl(
-                  this.templatePath('Task/task.ts'),
+                  this.templatePath('task/task.ts'),
                   this.destinationPath(taskFolder + '/' + this.taskName + '.ts'), tokens
             );
 
             this.fs.copyTpl(
-                  this.templatePath('Task/package.json'),
+                  this.templatePath('task/package.json'),
                   this.destinationPath(taskFolder + '/' + 'package.json'), tokens
             );
 
@@ -204,12 +204,12 @@ function writeFiles() {
 
 
       this.fs.copyTpl(
-            this.templatePath('Task/task.json'),
+            this.templatePath('task/task.json'),
             this.destinationPath(taskFolder + '/task.json'), tokens
 
       );
       this.fs.copy(
-            this.templatePath('Task/icon.png'),
+            this.templatePath('task/icon.png'),
             this.destinationPath(taskFolder + '/icon.png')
       );
 
@@ -249,13 +249,13 @@ function writeFiles() {
 
       if (this.useVS) {
             this.fs.copyTpl(
-                  this.templatePath('extId.csproj'),
+                  this.templatePath('ExtId.csproj'),
                   this.destinationPath(extensionFolder + '/' + this.extId + '.csproj'), tokens
             );
 
 
             this.fs.copyTpl(
-                  this.templatePath('extId.sln'),
+                  this.templatePath('ExtId.sln'),
                   this.destinationPath(this.extId + '/' + this.extId + '.sln'), tokens
             );
 
@@ -286,7 +286,7 @@ function install() {
       this.spawnCommandSync('npm', ['install'], { stdio: ['pipe', 'pipe', process.stderr] });
 
       this.log(`+ Running npm run package for vsix generating`);
-     
+
       if (this.taskScripting == "TypeScript") {
             this.spawnCommandSync('npm', ['run', 'install-task-lib'], { stdio: ['pipe', 'pipe', process.stderr] });
       }

--- a/generators/taskitem/templates/vss-extension.json
+++ b/generators/taskitem/templates/vss-extension.json
@@ -28,7 +28,7 @@
   ],
   "screenshots": [
     {
-      "path": "static/images/screen1.png"
+      "path": "static/images/Screen1.png"
     }
   ],
   "content": {

--- a/test/taskTests.js
+++ b/test/taskTests.js
@@ -46,25 +46,24 @@ describe('generator-team-services-extension-task-Powershell', function () {
 
 
   it('generator-team-services-extension-task-Powershell:creates files', () => {
-    var root = testPath + '\\TestextTaskId1\\TestextTaskId1\\';
-    var taskPath = root + "taskName1\\"
+    var root = testPath + '/TestextTaskId1/TestextTaskId1/';
+    var taskPath = root + 'taskName1/';
     assert.file([
       root + 'TestextTaskId1.csproj',
       root + 'package.json',
       root + 'vss-extension.json',
       root + 'static/images/logo.png',
-      root + 'static/images/screen1.png',
+      root + 'static/images/Screen1.png',
       root + 'license.md',
       root + 'overview.md',
       root + 'ThirdPartyNotices.txt',
-      taskPath + "taskName1.ps1",
-      taskPath + "task.json",
-      taskPath + "icon.png"
+      taskPath + 'taskName1.ps1',
+      taskPath + 'task.json',
+      taskPath + 'icon.png'
     ]);
     assert.fileContent(root + 'vss-extension.json', /"id": "TestextTaskId1"/);
-    assert.fileContent(root + 'vss-extension.json', /"name": "TestextTask1"/)
-
-  })
+    assert.fileContent(root + 'vss-extension.json', /"name": "TestextTask1"/);
+  });
 
   it(`generator-team-services-extension-task-Powershell:npm install should be called`, () => {
     assert.equal(1, spawnStub.withArgs(`npm`, [`install`], { stdio: ['pipe', 'pipe', process.stderr] }).callCount, `npm install was not be called`);
@@ -115,28 +114,27 @@ describe('generator-team-services-extension-task-TypeScript', function () {
 
 
   it('generator-team-services-extension-task-TypeScript:creates files', () => {
-    var root = testPath + '\\TestextTaskId1\\TestextTaskId1\\';
-    var taskPath = root + "taskName1\\"
+    var root = testPath + '/TestextTaskId1/TestextTaskId1/';
+    var taskPath = root + 'taskName1/';
     assert.file([
       root + 'TestextTaskId1.csproj',
       root + 'package.json',
       root + 'vss-extension.json',
       root + 'static/images/logo.png',
-      root + 'static/images/screen1.png',
+      root + 'static/images/Screen1.png',
       root + 'license.md',
       root + 'overview.md',
       root + 'ThirdPartyNotices.txt',
       root + 'tsconfig.json',
-      taskPath + "taskName1.ts",
-      taskPath + "package.json",
-      taskPath + "task.json",
-      taskPath + "icon.png"
+      taskPath + 'taskName1.ts',
+      taskPath + 'package.json',
+      taskPath + 'task.json',
+      taskPath + 'icon.png'
     ]);
-    
-    assert.fileContent(root + 'vss-extension.json', /"id": "TestextTaskId1"/);
-    assert.fileContent(root + 'vss-extension.json', /"name": "TestextTask1"/)
 
-  })
+    assert.fileContent(root + 'vss-extension.json', /"id": "TestextTaskId1"/);
+    assert.fileContent(root + 'vss-extension.json', /"name": "TestextTask1"/);
+  });
 
   it(`generator-team-services-extension-task-TypeScript:npm install should be called`, () => {
     assert.equal(1, spawnStub.withArgs(`npm`, [`install`], { stdio: ['pipe', 'pipe', process.stderr] }).callCount, `npm install was not be called`);


### PR DESCRIPTION
After trying to run the generator on my Arch Linux WSL environment, I saw that there were some files that were failing to be copied (breaking the whole process) due to mismatch from file and config capitalization. This isn't an issue in Windows due to the file system being case insensitive, but is an issue in Linux.

Main problem with the Task Generator was the capitalization of the "tasks" source folder when copying files to the generator output folder. There was also a mismatch for the screenshot file.

The problems with the tests was both capitalization and file paths being Windows specific.

Also modified the taskTests to be more OS safe. Windows doesn't seem to care about paths with "/" but Linux/Node does not agree with "\" in paths. 

Please let me know if this type of work is appreciated and I can look at the rest of the generators. ❤️ 

@ALM-Rangers/generator-vsts-extension
